### PR TITLE
Create simple systemd timer!

### DIFF
--- a/pingme.service
+++ b/pingme.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Issy has a custom pinging service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/run.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/pingme.timer
+++ b/pingme.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=15min timer
+
+[Timer]
+OnBootSec=0min
+OnCalendar=*:0 
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
To install these, put them in the /etc/systemd/services folder or something similar, do `systemctl start pingme.timer` and `systemctl enable pingme.timer`.

For debugging, logging and such you can use:
`systemctl status pingme` or `journalctl -u pingme`.